### PR TITLE
A beautiful workaround for setuptools deficiencies 

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -85,8 +85,6 @@ if [ $isEnv -eq 1 ]; then
     echo "[*] Python environment successfully activated"
     echo "[+] Installing dependencies, this may take a while..."
     python3 $setupFile install
-    echo "[*] SciPy makes a mess on setuptools, so... installing SciPy via pip..."
-    pip install scipy
     echo "[*] Done! Use "
     echo -e "\tsource ../$1/bin/activate"
     echo "to enable the Virtual Environment"

--- a/setupBackend.py
+++ b/setupBackend.py
@@ -5,20 +5,27 @@ from setuptools import setup
 def read(filename):
 	return open(os.path.join(os.path.dirname(__file__), filename)).read()
 
+def _post_install(setup):
+	def _install_scipy():
+		os.system('pip install scipy')
+	_install_scipy()
+	return setup
 
-setup(
-	name='GII_0_17.02_SNSI',
-	version='0.2.0a0',
-	author='Mario Bartolome',
-	author_email='mbm0089@alu.ubu.es',
-	long_description=read('README.md'),
-	packages=['backend'],
-	include_package_data=True,
-	install_requires=[
-		'pyserial',
-		'numpy',
-		'Bluetin_Echo',
-		'pytest'
-	],
-	zip_safe=False
+setup = _post_install(
+	setup(
+		name='GII_0_17.02_SNSI',
+		version='0.2.0a0',
+		author='Mario Bartolome',
+		author_email='mbm0089@alu.ubu.es',
+		long_description=read('README.md'),
+		packages=['backend'],
+		include_package_data=True,
+		install_requires=[
+			'pyserial',
+			'numpy',
+			'Bluetin_Echo',
+			'pytest'
+		],
+		zip_safe=False
+	)
 )


### PR DESCRIPTION
It doesn't seems to be an easy way to make an post-installation with setuptools!! 
So, just decorate the call to setup() funct.
Check [this](https://stackoverflow.com/questions/20288711/post-install-script-with-python-setuptools/50741718) and [this](https://stackoverflow.com/questions/17806485/execute-a-python-script-post-install-using-distutils-setuptools/50741573)